### PR TITLE
fix(website): improve mobile navigation layout spacing

### DIFF
--- a/docs/website/_layouts/default.html
+++ b/docs/website/_layouts/default.html
@@ -40,9 +40,10 @@
       margin-top: 20px;
     }
     nav a {
+      display: inline-block;
       color: #333;
       text-decoration: none;
-      margin: 0 12px;
+      margin: 8px 6px;
       padding: 8px 16px;
       border: 1px solid #ddd;
       border-radius: 6px;
@@ -52,6 +53,13 @@
     nav a:hover {
       background: #f5f5f5;
       border-color: #ccc;
+    }
+    @media (max-width: 600px) {
+      nav a {
+        margin: 6px 4px;
+        padding: 6px 12px;
+        font-size: 0.85rem;
+      }
     }
     main {
       min-height: 400px;


### PR DESCRIPTION
- Add display: inline-block to nav links for proper wrapping
- Add vertical margins (8px) to prevent buttons sticking together
- Add mobile media query for better spacing on small screens
- Reduce padding and font-size on mobile for better fit